### PR TITLE
bug(thumbnails): stack thumbnails on smaller screen sizes

### DIFF
--- a/src/components/Body/section2.jsx
+++ b/src/components/Body/section2.jsx
@@ -27,10 +27,11 @@ class Section2 extends React.Component {
         <h3 className="page-header text-center capitalize">
            Headlines from {this.props.data.list.source.replace(/-/g, ' ')}
         </h3>
-        <div className="flex-row row">
-          {
+        <div className="container-fluid">
+          <div className="row flex-row">
+            {
           Object.keys(this.props.data.list.articles).map(key => (
-            <div className="col-xs-4 col-lg-4">
+            <div className="col-lg-4 col-xs-12">
               <div className="thumbnail">
                 <img
                   style={{ width: 405 }}
@@ -41,7 +42,7 @@ class Section2 extends React.Component {
                   <h4 className="flex-text text-primary">
                     <span className="title">{(this.props.data.list.articles[key].title)}</span>
                   </h4>
-                  <p className="flex-text">
+                  <p className="flex-text text-justify">
                     {(this.props.data.list.articles[key].description)}
                   </p>
                 </div>
@@ -84,6 +85,7 @@ class Section2 extends React.Component {
             </div>
             ),
           )}
+          </div>
         </div>
       </div>
     );

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -102,10 +102,10 @@ html {
     border: 4px solid white;
 }
 .thumbnail:hover{
-   border: 4px solid dodgerblue;
+   border: 2px solid dodgerblue;
    -moz-box-shadow: 5px 5px 0px #999;
     -webkit-box-shadow: 5px 5px 0px #999;
-    box-shadow: 2px 2px 2px #999;
+    box-shadow: 3px 3px 3px #999;
 }
 
 .user-name:hover:first-of-type {


### PR DESCRIPTION
#### What does this PR do?
This Pr stacks thumbnails on smaller screen sizes
#### How should this be manually tested?
Resizing the  browser window
#### Any background context you want to provide?
Before this thumbnails were a grid on smaller screen sizes
#### What are the relevant pivotal tracker stories?
none
#### Screenshots (if appropriate)
#### Questions:

